### PR TITLE
https://github.com/smallnest/gen/issues/17

### DIFF
--- a/dbmeta/meta.go
+++ b/dbmeta/meta.go
@@ -84,9 +84,19 @@ const (
 	golangTime       = "time.Time"
 )
 
+// driverDialect is a registry, mapping database/sql driver names to database dialects.
+// This is somewhat fragile.
+var tableNameFormat map[string]string = map[string]string{
+	"sqlite":   "`%s`",
+	"postgres": "`%s`",
+	"mysql":    "`%s`",
+	"mssql":    "%s",
+	"oracle":   "`%s`",
+}
+
 // GenerateStruct generates a struct for the given table.
-func GenerateStruct(db *sql.DB, tableName string, structName string, pkgName string, jsonAnnotation bool, gormAnnotation bool, gureguTypes bool) *ModelInfo {
-	cols, _ := schema.Table(db, "`"+tableName+"`")
+func GenerateStruct(db *sql.DB, sqlType string, tableName string, structName string, pkgName string, jsonAnnotation bool, gormAnnotation bool, gureguTypes bool) *ModelInfo {
+	cols, _ := schema.Table(db, fmt.Sprintf(tableNameFormat[sqlType], tableName))
 	fields := generateFieldsTypes(db, cols, 0, jsonAnnotation, gormAnnotation, gureguTypes)
 
 	//fields := generateMysqlTypes(db, columnTypes, 0, jsonAnnotation, gormAnnotation, gureguTypes)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 // indirect
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/guregu/null v3.4.0+incompatible
-	github.com/jimsmart/schema v0.0.0-20181113191328-8d0563922e25
+	github.com/jimsmart/schema v0.0.0-20191104172732-39e4bec5335f
 	github.com/jinzhu/gorm v1.9.4
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a
 	github.com/jinzhu/now v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
-github.com/jimsmart/schema v0.0.0-20181113191328-8d0563922e25 h1:ApI3RQzYrspNCHCbL1Ki15Qy3sA9qFqwRELTXRY8Oq8=
-github.com/jimsmart/schema v0.0.0-20181113191328-8d0563922e25/go.mod h1:s402qSZ/H+MBuvTa9BDxzA8jKJKLOyNEZg9/YZF2C0M=
+github.com/jimsmart/schema v0.0.0-20191104172732-39e4bec5335f h1:iglhLNJdBiU9MdQswh66+JhU46d5s39NrEgkxXPJtjk=
+github.com/jimsmart/schema v0.0.0-20191104172732-39e4bec5335f/go.mod h1:s402qSZ/H+MBuvTa9BDxzA8jKJKLOyNEZg9/YZF2C0M=
 github.com/jinzhu/gorm v1.9.4 h1:3KDoUjMEfH58nweXdD5Dng222YiwOVUNFShENhehJyQ=
 github.com/jinzhu/gorm v1.9.4/go.mod h1:7ZYqlk/T0SqZip7ZOIL1aC/sjDj+dJo6sN98WljHFXY=
 github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a h1:eeaG9XMUvRBYXJi4pg1ZKM7nxc5AfXfojeLLW7O5J3k=

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 		structName = inflection.Singular(structName)
 		structNames = append(structNames, structName)
 
-		modelInfo := dbmeta.GenerateStruct(db, tableName, structName, "model", *jsonAnnotation, *gormAnnotation, *gureguTypes)
+		modelInfo := dbmeta.GenerateStruct(db, *sqlType, tableName, structName, "model", *jsonAnnotation, *gormAnnotation, *gureguTypes)
 
 		var buf bytes.Buffer
 		err = t.Execute(&buf, modelInfo)


### PR DESCRIPTION
was fixed in the following
https://github.com/jimsmart/schema/issues/6

This is pulling the latest
	github.com/jimsmart/schema v0.0.0-20191104172732-39e4bec5335f
which has the mssql.Driver mapped in.

Further testing showed that there seems to be a difference between how mssql accepts a table from in the FROM statement.
````
i.e. FROM Vehicle and NOT FROM `Vehicle`
````


https://github.com/jimsmart/schema/issues/10

To be backwards compatible with the jimsmart/schema library I am passing in the right table format based on the sqlType