### PR TITLE
Better linting for vs code & typo & getById method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 	$(warning "found packr2")
 
 
-install: ## go install binary info $GOPATH/binn
+install: ## go install binary info $GOPATH/bin
 	packr2 install github.com/smallnest/gen
 
 vet: ## run go vet on the project

--- a/custom/custom.go.tmpl
+++ b/custom/custom.go.tmpl
@@ -18,21 +18,21 @@ func GetAll{{pluralize .StructName}}(ctx context.Context, page, pagesize int64, 
 
 	{{pluralize .StructName | toLower}} = []*{{.modelPackageName}}.{{.StructName}}{}
 
-	{{pluralize .StructName | toLower}}_orm := DB.Model(&{{.modelPackageName}}.{{.StructName}}{})
-    {{pluralize .StructName | toLower}}_orm.Count(&totalRows)
+	{{pluralize .StructName | toLower}}Orm := DB.Model(&{{.modelPackageName}}.{{.StructName}}{})
+    {{pluralize .StructName | toLower}}Orm.Count(&totalRows)
 
 	if page > 0 {
 		offset := (page - 1) * pagesize
-		{{pluralize .StructName | toLower}}_orm = {{pluralize .StructName | toLower}}_orm.Offset(offset).Limit(pagesize)
+		{{pluralize .StructName | toLower}}Orm = {{pluralize .StructName | toLower}}Orm.Offset(offset).Limit(pagesize)
 	} else {
-		{{pluralize .StructName | toLower}}_orm = {{pluralize .StructName | toLower}}_orm.Limit(pagesize)
+		{{pluralize .StructName | toLower}}Orm = {{pluralize .StructName | toLower}}Orm.Limit(pagesize)
     }
 
 	if order != "" {
-		{{pluralize .StructName | toLower}}_orm = {{pluralize .StructName | toLower}}_orm.Order(order)
+		{{pluralize .StructName | toLower}}Orm = {{pluralize .StructName | toLower}}Orm.Order(order)
 	}
 
-	if err = {{pluralize .StructName | toLower}}_orm.Find(&{{pluralize .StructName | toLower}}).Error; err != nil {
+	if err = {{pluralize .StructName | toLower}}Orm.Find(&{{pluralize .StructName | toLower}}).Error; err != nil {
 	    err = NotFound
 		return nil, -1, err
 	}

--- a/template/dao.go.tmpl
+++ b/template/dao.go.tmpl
@@ -9,7 +9,7 @@ import (
 )
 
 
-// GetAll{{.StructName}} is a function to get a slice of record(s) from {{.TableName}} table in the {{.DatabaseName}} database
+// GetAll{{pluralize .StructName}} is a function to get a slice of record(s) from {{.TableName}} table in the {{.DatabaseName}} database
 // params - page     - page requested (defaults to 0)
 // params - pagesize - number of records in a page  (defaults to 20)
 // params - order    - db sort order column
@@ -18,21 +18,21 @@ func GetAll{{pluralize .StructName}}(ctx context.Context, page, pagesize int64, 
 
 	{{pluralize .StructName | toLower}} = []*{{.modelPackageName}}.{{.StructName}}{}
 
-	{{pluralize .StructName | toLower}}_orm := DB.Model(&{{.modelPackageName}}.{{.StructName}}{})
-    {{pluralize .StructName | toLower}}_orm.Count(&totalRows)
+	{{pluralize .StructName | toLower}}Orm := DB.Model(&{{.modelPackageName}}.{{.StructName}}{})
+    {{pluralize .StructName | toLower}}Orm.Count(&totalRows)
 
 	if page > 0 {
 		offset := (page - 1) * pagesize
-		{{pluralize .StructName | toLower}}_orm = {{pluralize .StructName | toLower}}_orm.Offset(offset).Limit(pagesize)
+		{{pluralize .StructName | toLower}}Orm = {{pluralize .StructName | toLower}}Orm.Offset(offset).Limit(pagesize)
 	} else {
-		{{pluralize .StructName | toLower}}_orm = {{pluralize .StructName | toLower}}_orm.Limit(pagesize)
+		{{pluralize .StructName | toLower}}Orm = {{pluralize .StructName | toLower}}Orm.Limit(pagesize)
     }
 
 	if order != "" {
-		{{pluralize .StructName | toLower}}_orm = {{pluralize .StructName | toLower}}_orm.Order(order)
+		{{pluralize .StructName | toLower}}Orm = {{pluralize .StructName | toLower}}Orm.Order(order)
 	}
 
-	if err = {{pluralize .StructName | toLower}}_orm.Find(&{{pluralize .StructName | toLower}}).Error; err != nil {
+	if err = {{pluralize .StructName | toLower}}Orm.Find(&{{pluralize .StructName | toLower}}).Error; err != nil {
 	    err = NotFound
 		return nil, -1, err
 	}
@@ -42,10 +42,10 @@ func GetAll{{pluralize .StructName}}(ctx context.Context, page, pagesize int64, 
 
 // Get{{.StructName}} is a function to get a single record to {{.TableName}} table in the {{.DatabaseName}} database
 // error - NotFound, db Find error
-func Get{{.StructName}}(ctx context.Context, id interface{}) (record *{{.modelPackageName}}.{{.StructName}}, err error) {
-	if err = DB.First(record, id).Error; err != nil {
+func Get{{.StructName}}(ctx context.Context, id interface{}) (record {{.modelPackageName}}.{{.StructName}}, err error) {
+	if err = DB.First(&record, id).Error; err != nil {
 	    err = NotFound
-		return nil, err
+		return record, err
 	}
 
 	return record, nil
@@ -75,7 +75,6 @@ func Update{{.StructName}}(ctx context.Context, id interface{}, updated *{{.mode
 
    if err = dbmeta.Copy(result, updated); err != nil {
       return nil, -1, UpdateFailedError
-      return
    }
 
    db = db.Save(result)


### PR DESCRIPTION
* Fixed a typo in makefile
* GetModel was returning **unsupported destination, should be slice or struct**, fixed
* double declared return removed
* _orm variable was giving warning on vscode, changed to camel case