### PR TITLE
Separate listen and server port, add scheme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ Options:
   --generate-proj                                          Generate project readme and gitignore
   --rest                                                   Enable generating RESTful api
   --run-gofmt                                              run gofmt on output dir
+  --scheme=http                                            URL scheme for server
   --host=localhost                                         host for server
   --port=8080                                              port for server
+  --listen=                                                listen address for server e.g. 0.0.0.0:8080
   --swagger_version=1.0                                    swagger version
   --swagger_path=/                                         swagger base path
   --swagger_tos=                                           swagger tos url

--- a/dbmeta/codegen.go
+++ b/dbmeta/codegen.go
@@ -465,6 +465,8 @@ func (c *Config) WriteTemplate(genTemplate *GenTemplate, data map[string]interfa
 	data["sqlConnStr"] = c.SQLConnStr
 	data["serverPort"] = c.ServerPort
 	data["serverHost"] = c.ServerHost
+	data["serverScheme"] = c.ServerScheme
+	data["serverListen"] = c.ServerListen
 	data["SwaggerInfo"] = c.Swagger
 	data["outDir"] = c.OutDir
 	data["Config"] = c
@@ -604,6 +606,8 @@ type Config struct {
 	Swagger               *SwaggerInfoDetails
 	ServerPort            int
 	ServerHost            string
+	ServerScheme          string
+	ServerListen          string
 	Verbose               bool
 	OutDir                string
 	Overwrite             bool
@@ -669,6 +673,8 @@ func NewConfig(templateLoader TemplateLoader) *Config {
 
 	conf.ServerPort = 8080
 	conf.ServerHost = "127.0.0.1"
+	conf.ServerScheme = "http"
+	conf.ServerListen = ":8080"
 	conf.Overwrite = true
 
 	conf.Module = module
@@ -676,7 +682,11 @@ func NewConfig(templateLoader TemplateLoader) *Config {
 	conf.DaoFQPN = module + "/" + daoPackageName
 	conf.APIFQPN = module + "/" + apiPackageName
 
-	conf.Swagger.Host = fmt.Sprintf("%s:%d", conf.ServerHost, conf.ServerPort)
+	if conf.ServerPort == 80 {
+		conf.Swagger.Host = conf.ServerHost
+	} else {
+		conf.Swagger.Host = fmt.Sprintf("%s:%d", conf.ServerHost, conf.ServerPort)
+	}
 
 	return conf
 }

--- a/main.go
+++ b/main.go
@@ -76,6 +76,8 @@ var (
 	restAPIGenerate  = goopt.Flag([]string{"--rest"}, []string{}, "Enable generating RESTful api", "")
 	runGoFmt         = goopt.Flag([]string{"--run-gofmt"}, []string{}, "run gofmt on output dir", "")
 
+	serverListen        = goopt.String([]string{"--listen"}, "", "listen address e.g. :8080")
+	serverScheme        = goopt.String([]string{"--scheme"}, "http", "scheme for server url")
 	serverHost          = goopt.String([]string{"--host"}, "localhost", "host for server")
 	serverPort          = goopt.Int([]string{"--port"}, 8080, "port for server")
 	swaggerVersion      = goopt.String([]string{"--swagger_version"}, "1.0", "swagger version")
@@ -161,6 +163,13 @@ func main() {
 	if *saveTemplateDir != "" {
 		saveTemplates()
 		return
+	}
+
+	if *serverListen == "" {
+		*serverListen = fmt.Sprintf(":%d", *serverPort)
+	}
+	if *serverScheme != "http" && *serverScheme != "https" {
+		*serverScheme = "http"
 	}
 
 	if *nameTest != "" {
@@ -343,6 +352,8 @@ func initialize(conf *dbmeta.Config) {
 	conf.SQLConnStr = *sqlConnStr
 	conf.ServerPort = *serverPort
 	conf.ServerHost = *serverHost
+	conf.ServerScheme = *serverScheme
+	conf.ServerListen = *serverListen
 
 	conf.Module = *module
 	conf.ModelPackageName = *modelPackageName
@@ -369,7 +380,11 @@ func initialize(conf *dbmeta.Config) {
 	conf.Swagger.ContactName = *swaggerContactName
 	conf.Swagger.ContactURL = *swaggerContactURL
 	conf.Swagger.ContactEmail = *swaggerContactEmail
-	conf.Swagger.Host = fmt.Sprintf("%s:%d", *serverHost, *serverPort)
+	if *serverPort == 80 {
+		conf.Swagger.Host = *serverHost
+	} else {
+		conf.Swagger.Host = fmt.Sprintf("%s:%d", *serverHost, *serverPort)
+	}
 
 	conf.JSONNameFormat = strings.ToLower(conf.JSONNameFormat)
 	conf.XMLNameFormat = strings.ToLower(conf.XMLNameFormat)
@@ -431,6 +446,7 @@ func execTemplate(conf *dbmeta.Config, genTemplate *dbmeta.GenTemplate, data map
 	data["sqlConnStr"] = *sqlConnStr
 	data["serverPort"] = *serverPort
 	data["serverHost"] = *serverHost
+	data["serverListen"] = *serverListen
 	data["SwaggerInfo"] = conf.Swagger
 	data["tableInfos"] = tableInfos
 	data["CommandLine"] = conf.CmdLine

--- a/readme/main.go
+++ b/readme/main.go
@@ -166,6 +166,8 @@ func initialize(conf *dbmeta.Config) {
 	conf.SQLConnStr = *sqlConnStr
 	conf.ServerPort = 8080
 	conf.ServerHost = "127.0.0.1"
+	conf.ServerListen = ":8080"
+	conf.ServerScheme = "http"
 	conf.Overwrite = true
 
 	conf.Module = module
@@ -181,7 +183,11 @@ func initialize(conf *dbmeta.Config) {
 	conf.Swagger.ContactName = ""
 	conf.Swagger.ContactURL = ""
 	conf.Swagger.ContactEmail = ""
-	conf.Swagger.Host = fmt.Sprintf("%s:%d", conf.ServerHost, conf.ServerPort)
+	if conf.ServerPort == 80 {
+		conf.Swagger.Host = conf.ServerHost
+	} else {
+		conf.Swagger.Host = fmt.Sprintf("%s:%d", conf.ServerHost, conf.ServerPort)
+	}
 }
 
 func initializeDB() (db *sql.DB, err error) {

--- a/template/GEN_README.md.tmpl
+++ b/template/GEN_README.md.tmpl
@@ -81,7 +81,7 @@ $ cp ../../sample.db  .
 $ ./example
 
 
-## Open a browser to http://localhost:8080/swagger/index.html
+## Open a browser to {{$.serverScheme}}://{{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/swagger/index.html
 
 ## Use wget/curl/httpie to fetch via command line
 http http://localhost:8080/albums

--- a/template/README.md.tmpl
+++ b/template/README.md.tmpl
@@ -40,16 +40,16 @@ Will create a binary `./bin/example`
 ```.bash
 ./bin/example
 ```
-This will launch the web server on {{$.serverHost}}:{{$.serverPort}}
+This will launch the web server on {{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}
 
 ## Swagger
 The swagger web ui contains the documentation for the http server, it also provides an interactive interface to exercise the api and view results.
-http://{{.serverHost}}:{{.serverPort}}/swagger/index.html
+{{$.serverScheme}}://{{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/swagger/index.html
 
 ## REST urls for fetching data
 
 {{range $tableName, $codeInfo := .tableInfos}}
-* http://{{$.serverHost}}:{{$.serverPort}}/{{$codeInfo.StructName | toLower}}{{ end }}
+* {{$.serverScheme}}://{{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/{{$codeInfo.StructName | toLower}}{{ end }}
 
 ## Project Generated Details
 {{markdownCodeBlock ".bash" (.Config.CmdLineWrapped)}}

--- a/template/api_add.go.tmpl
+++ b/template/api_add.go.tmpl
@@ -10,7 +10,7 @@
 // @Failure 400 {object} {{.apiPackageName}}.HTTPError
 // @Failure 404 {object} {{.apiPackageName}}.HTTPError
 // @Router /{{.StructName | toLower}} [post]
-// echo '{{ToJSON .TableInfo.Instance 0}}' | http POST "http://{{$.serverHost}}:{{$.serverPort}}/{{.StructName | toLower}}" X-Api-User:user123
+// echo '{{ToJSON .TableInfo.Instance 0}}' | http POST "{{$.serverScheme}}://{{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/{{.StructName | toLower}}" X-Api-User:user123
 func Add{{.StructName}}(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := initializeContext(r)
 	{{.StructName | toLower}} := &{{.modelPackageName}}.{{.StructName}}{}

--- a/template/api_delete.go.tmpl
+++ b/template/api_delete.go.tmpl
@@ -10,7 +10,7 @@
 // @Failure 400 {object} {{.apiPackageName}}.HTTPError
 // @Failure 500 {object} {{.apiPackageName}}.HTTPError
 // @Router /{{.StructName | toLower}}{{range $field := .TableInfo.CodeFields}}{{ if $field.PrimaryKeyArgName}}/{ {{- $field.PrimaryKeyArgName -}} }{{end}}{{end}} [delete]
-// http DELETE "http://{{$.serverHost}}:{{$.serverPort}}/{{.StructName | toLower}}{{range $field := .TableInfo.CodeFields}}{{ if $field.PrimaryKeyArgName}}/{{ $field.FakeData }}{{end}}{{end}}" X-Api-User:user123
+// http DELETE "{{$.serverScheme}}://{{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/{{.StructName | toLower}}{{range $field := .TableInfo.CodeFields}}{{ if $field.PrimaryKeyArgName}}/{{ $field.FakeData }}{{end}}{{end}}" X-Api-User:user123
 func Delete{{.StructName}}(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := initializeContext(r)
 {{range $field := .TableInfo.CodeFields}}

--- a/template/api_get.go.tmpl
+++ b/template/api_get.go.tmpl
@@ -9,7 +9,7 @@
 // @Failure 400 {object} {{.apiPackageName}}.HTTPError
 // @Failure 404 {object} {{.apiPackageName}}.HTTPError "ErrNotFound, db record for id not found - returns NotFound HTTP 404 not found error"
 // @Router /{{.StructName | toLower}}{{range $field := .TableInfo.CodeFields}}{{ if $field.PrimaryKeyArgName}}/{ {{- $field.PrimaryKeyArgName -}} }{{end}}{{end}} [get]
-// http "http://{{$.serverHost}}:{{$.serverPort}}/{{.StructName | toLower}}{{range $field := .TableInfo.CodeFields}}{{ if $field.PrimaryKeyArgName}}/{{ $field.FakeData }}{{end}}{{end}}" X-Api-User:user123
+// http "{{$.serverScheme}}://{{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/{{.StructName | toLower}}{{range $field := .TableInfo.CodeFields}}{{ if $field.PrimaryKeyArgName}}/{{ $field.FakeData }}{{end}}{{end}}" X-Api-User:user123
 func Get{{.StructName}}(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := initializeContext(r)
 {{range $field := .TableInfo.CodeFields}}

--- a/template/api_getall.go.tmpl
+++ b/template/api_getall.go.tmpl
@@ -12,7 +12,7 @@
 // @Failure 400 {object} {{.apiPackageName}}.HTTPError
 // @Failure 404 {object} {{.apiPackageName}}.HTTPError
 // @Router /{{.StructName | toLower}} [get]
-// http "http://{{$.serverHost}}:{{$.serverPort}}/{{.StructName | toLower}}?page=0&pagesize=20" X-Api-User:user123
+// http "{{$.serverScheme}}://{{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/{{.StructName | toLower}}?page=0&pagesize=20" X-Api-User:user123
 func GetAll{{.StructName}}(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := initializeContext(r)
     page, err := readInt(r, "page", 0)

--- a/template/api_update.go.tmpl
+++ b/template/api_update.go.tmpl
@@ -10,8 +10,8 @@
 // @Success 200 {object} {{.modelPackageName}}.{{.StructName}}
 // @Failure 400 {object} {{.apiPackageName}}.HTTPError
 // @Failure 404 {object} {{.apiPackageName}}.HTTPError
-// @Router /{{.StructName | toLower}}{{range $field := .TableInfo.CodeFields}}{{ if $field.PrimaryKeyArgName}}/{ {{- $field.PrimaryKeyArgName -}} }{{end}}{{end}} [patch]
-// echo '{{ToJSON .TableInfo.Instance 0}}' | http PUT "http://{{$.serverHost}}:{{$.serverPort}}/{{.StructName | toLower}}{{range $field := .TableInfo.CodeFields}}{{ if $field.PrimaryKeyArgName}}/{{ $field.FakeData }}{{end}}{{end}}"  X-Api-User:user123
+// @Router /{{.StructName | toLower}}{{range $field := .TableInfo.CodeFields}}{{ if $field.PrimaryKeyArgName}}/{ {{- $field.PrimaryKeyArgName -}} }{{end}}{{end}} [put]
+// echo '{{ToJSON .TableInfo.Instance 0}}' | http PUT "{{$.serverScheme}}://{{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/{{.StructName | toLower}}{{range $field := .TableInfo.CodeFields}}{{ if $field.PrimaryKeyArgName}}/{{ $field.FakeData }}{{end}}{{end}}"  X-Api-User:user123
 func Update{{.StructName}}(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := initializeContext(r)
 {{range $field := .TableInfo.CodeFields}}

--- a/template/dao_gorm_get.go.tmpl
+++ b/template/dao_gorm_get.go.tmpl
@@ -2,7 +2,8 @@
 // Get{{.StructName}} is a function to get a single record from the {{.TableName}} table in the {{.DatabaseName}} database
 // error - ErrNotFound, db Find error
 func Get{{.StructName}}(ctx context.Context,{{range $field := .TableInfo.CodeFields}} {{ if $field.PrimaryKeyArgName }} {{$field.PrimaryKeyArgName}} {{$field.GoFieldType}},{{end}}{{end -}}) (record *{{.modelPackageName}}.{{.StructName}}, err error) {
-	if err = DB.First(&record, {{range $field := .TableInfo.CodeFields}} {{ if $field.PrimaryKeyArgName }} {{$field.PrimaryKeyArgName}},{{end}}{{end -}}).Error; err != nil {
+	record = &{{.modelPackageName}}.{{.StructName}}{}
+	if err = DB.First(record, {{range $field := .TableInfo.CodeFields}} {{ if $field.PrimaryKeyArgName }} {{$field.PrimaryKeyArgName}},{{end}}{{end -}}).Error; err != nil {
 	    err = ErrNotFound
 		return record, err
 	}

--- a/template/main_gorm.go.tmpl
+++ b/template/main_gorm.go.tmpl
@@ -49,13 +49,13 @@ var (
 
 // GinServer launch gin server
 func GinServer() (err error){
-	url := ginSwagger.URL("http://{{.serverHost}}:{{.serverPort}}/swagger/doc.json") // The url pointing to API definition
+	url := ginSwagger.URL("{{$.serverScheme}}://{{.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/swagger/doc.json") // The url pointing to API definition
 
 	router := gin.Default()
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
 
 	{{.apiPackageName}}.ConfigGinRouter(router)
-	router.Run(":{{.serverPort}}")
+	router.Run("{{.serverListen}}")
 	if err != nil {
 		log.Fatalf("Error starting server, the error is '%v'", err)
 	}
@@ -77,7 +77,7 @@ func GinServer() (err error){
 // @license.name Apache 2.0
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 
-// @host {{.serverHost}}:{{.serverPort}}
+// @host {{.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}
 // @BasePath {{.SwaggerInfo.BasePath}}
 func main() {
     OsSignal = make(chan os.Signal, 1)

--- a/template/main_sqlx.go.tmpl
+++ b/template/main_sqlx.go.tmpl
@@ -63,13 +63,13 @@ func (u *User) String() string {
 
 // GinServer launch gin server
 func GinServer() (err error){
-	url := ginSwagger.URL("http://{{.serverHost}}:{{.serverPort}}/swagger/doc.json") // The url pointing to API definition
+	url := ginSwagger.URL("{{$.serverScheme}}://{{.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/swagger/doc.json") // The url pointing to API definition
 
 	router := gin.Default()
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
 
 	{{.apiPackageName}}.ConfigGinRouter(router)
-	err = router.Run(":{{.serverPort}}")
+	err = router.Run("{{.serverListen}}")
 	if err != nil {
 		log.Fatalf("Error starting server, the error is '%v'", err)
 	}
@@ -91,7 +91,7 @@ func GinServer() (err error){
 // @license.name Apache 2.0
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 
-// @host {{.serverHost}}:{{.serverPort}}
+// @host {{.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}
 // @BasePath {{.SwaggerInfo.BasePath}}
 func main() {
     OsSignal = make(chan os.Signal, 1)

--- a/template/router.go.tmpl
+++ b/template/router.go.tmpl
@@ -288,7 +288,7 @@ func parseUUID(ps httprouter.Params, key string) (string, error) {
 // @Failure 400 {object} {{.apiPackageName}}.HTTPError
 // @Failure 404 {object} {{.apiPackageName}}.HTTPError "ErrNotFound, db record for id not found - returns NotFound HTTP 404 not found error"
 // @Router /ddl/{argID} [get]
-// http "http://localhost:8080/ddl/xyz" X-Api-User:user123
+// http "{{$.serverScheme}}://{{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/ddl/xyz" X-Api-User:user123
 func GetDdl(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := initializeContext(r)
 
@@ -318,7 +318,7 @@ func GetDdl(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 // @Produce  json
 // @Success 200 {object} {{.apiPackageName}}.CrudAPI
 // @Router /ddl [get]
-// http "http://localhost:8080/ddl" X-Api-User:user123
+// http "{{$.serverScheme}}://{{$.serverHost}}{{if ne $.serverPort 80}}:{{$.serverPort}}{{end}}/ddl" X-Api-User:user123
 func GetDdlEndpoints(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	ctx := initializeContext(r)
 


### PR DESCRIPTION
Added `--scheme` and `--listen` options. This allows compiled binary to be used behind reverse proxy. 
In addition, template for generating URL was fixed, i.e. when `PORT` is `80`, then `PORT` is omitted from URL segment.
