### PR TITLE
Adhere json-fmt for all responses, fix and build info

### DIFF
--- a/dbmeta/codegen.go
+++ b/dbmeta/codegen.go
@@ -356,6 +356,21 @@ func escape(content string) string {
 	return content
 }
 
+// JSONFieldName convert name to appropriate case
+func (c *Config) JSONFieldName(name string) string {
+	return formatFieldName(c.JSONNameFormat, name)
+}
+
+// JSONTag converts name to `json:"name"` respecting json-fmt option
+func (c *Config) JSONTag(name string) string {
+	return fmt.Sprintf("`json:\"%s\"`", c.JSONFieldName(name))
+}
+
+// JSONTagOmitEmpty converts name to JSON tag with omitempty
+func (c *Config) JSONTagOmitEmpty(name string) string {
+	return fmt.Sprintf("`json:\"%s,omitempty\"`", c.JSONFieldName(name))
+}
+
 // GenerateTableFile generate file from template using specific table used within templates
 func (c *Config) GenerateTableFile(tableInfos map[string]*ModelInfo, tableName, templateFilename, outputDirectory, outputFileName string, formatOutput bool) string {
 	buf := bytes.Buffer{}

--- a/template/Makefile.tmpl
+++ b/template/Makefile.tmpl
@@ -7,6 +7,7 @@ export BUILT_ON_IP := $(shell [ $$(uname) = Linux ] && hostname -i || hostname )
 export BIN_DIR=./bin
 export PACKR2_EXECUTABLE := $(shell command -v packr2  2> /dev/null)
 export SWAG_EXECUTABLE := $(shell command -v swag  2> /dev/null)
+export RUNTIME_VER := $(shell go version)
 
 export BUILT_ON_OS=$(shell uname -a)
 ifeq ($(BRANCH),)
@@ -15,11 +16,12 @@ endif
 
 export COMMIT_CNT := $(shell git rev-list HEAD | wc -l | sed 's/ //g' )
 export BUILD_NUMBER := ${BRANCH}-${COMMIT_CNT}
-export COMPILE_LDFLAGS=-s -X "main.DATE=${DATE}" \
-                          -X "main.LATEST_COMMIT=${LATEST_COMMIT}" \
-                          -X "main.BUILD_NUMBER=${BUILD_NUMBER}" \
-                          -X "main.BUILT_ON_IP=${BUILT_ON_IP}" \
-                          -X "main.BUILT_ON_OS=${BUILT_ON_OS}"
+export COMPILE_LDFLAGS=-s -X "main.BuildDate=${DATE}" \
+                          -X "main.LatestCommit=${LATEST_COMMIT}" \
+                          -X "main.BuildNumber=${BUILD_NUMBER}" \
+                          -X "main.BuiltOnIP=${BUILT_ON_IP}" \
+                          -X "main.BuiltOnOs=${BUILT_ON_OS}" \
+						  -X "main.RuntimeVer=${RUNTIME_VER}"
 
 build_info: check_prereq ## Build the container
 	@echo ''
@@ -35,6 +37,7 @@ build_info: check_prereq ## Build the container
 	@echo 'PATH              $(PATH)'
 	@echo 'PACKR2_EXECUTABLE $(PACKR2_EXECUTABLE)'
 	@echo 'SWAG_EXECUTABLE   $(SWAG_EXECUTABLE)'
+	@echo 'RUNTIME_VER       $(RUNTIME_VER)'
 	@echo '---------------------------------------------------------'
 	@echo ''
 

--- a/template/main_gorm.go.tmpl
+++ b/template/main_gorm.go.tmpl
@@ -17,6 +17,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/swaggo/files"       // swagger embed files
 	"github.com/swaggo/gin-swagger" // gin-swagger middleware
+	"github.com/droundy/goopt"
 
 	"{{.module}}/{{.apiPackageName}}"
     "{{.module}}/{{.daoPackageName}}"
@@ -81,6 +82,17 @@ func GinServer() (err error){
 // @BasePath {{.SwaggerInfo.BasePath}}
 func main() {
     OsSignal = make(chan os.Signal, 1)
+
+	// Define version information
+	goopt.Version = fmt.Sprintf(
+`Application build information
+  Build date      : %s
+  Build number    : %s
+  Git commit      : %s
+  Runtime version : %s
+  Built on OS     : %s
+`, BuildDate, BuildNumber, LatestCommit, RuntimeVer, BuiltOnOs)
+	goopt.Parse(nil)
 
 	db, err := gorm.Open("{{.sqlType}}", "{{.sqlConnStr}}")
 	if err != nil {

--- a/template/main_sqlx.go.tmpl
+++ b/template/main_sqlx.go.tmpl
@@ -13,6 +13,7 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/swaggo/gin-swagger/swaggerFiles"
 	"github.com/gin-gonic/gin"
+	"github.com/droundy/goopt"
 
     _ "github.com/denisenkom/go-mssqldb"
     _ "github.com/go-sql-driver/mysql"
@@ -95,6 +96,17 @@ func GinServer() (err error){
 // @BasePath {{.SwaggerInfo.BasePath}}
 func main() {
     OsSignal = make(chan os.Signal, 1)
+
+	// Define version information
+	goopt.Version = fmt.Sprintf(
+`Application build information
+  Build date      : %s
+  Build number    : %s
+  Git commit      : %s
+  Runtime version : %s
+  Built on OS     : %s
+`, BuildDate, BuildNumber, LatestCommit, RuntimeVer, BuiltOnOs)
+	goopt.Parse(nil)
 
 	db, err := sqlx.Open("{{.sqlType}}", "{{.sqlConnStr}}")
 	if err != nil {

--- a/template/model_base.go.tmpl
+++ b/template/model_base.go.tmpl
@@ -66,31 +66,31 @@ type Model interface {
 
 // TableInfo describes a table in the database
 type TableInfo struct {
-	Name    string        `json:"name"`
-	Columns []*ColumnInfo `json:"columns"`
+	Name    string        {{ .Config.JSONTag "name" }}
+	Columns []*ColumnInfo {{ .Config.JSONTag "columns" }}
 }
 
 // ColumnInfo describes a column in the database table
 type ColumnInfo struct {
-	Index              int    `json:"index"`
-	GoFieldName        string `json:"go_field_name"`
-	GoFieldType        string `json:"go_field_type"`
-	JSONFieldName      string `json:"json_field_name"`
-	ProtobufFieldName  string `json:"protobuf_field_name"`
-	ProtobufType       string `json:"protobuf_field_type"`
-	ProtobufPos        int    `json:"protobuf_field_pos"`
-	Comment            string `json:"comment"`
-	Notes              string `json:"notes"`
-	Name               string `json:"name"`
-	Nullable           bool   `json:"is_nullable"`
-	DatabaseTypeName   string `json:"database_type_name"`
-	DatabaseTypePretty string `json:"database_type_pretty"`
-	IsPrimaryKey       bool   `json:"is_primary_key"`
-	IsAutoIncrement    bool   `json:"is_auto_increment"`
-	IsArray            bool   `json:"is_array"`
-	ColumnType         string `json:"column_type"`
-	ColumnLength       int64  `json:"column_length"`
-	DefaultValue       string `json:"default_value"`
+	Index              int    {{ .Config.JSONTag "index" }}
+	GoFieldName        string {{ .Config.JSONTag "go_field_name" }}
+	GoFieldType        string {{ .Config.JSONTag "go_field_type" }}
+	JSONFieldName      string {{ .Config.JSONTag "json_field_name" }}
+	ProtobufFieldName  string {{ .Config.JSONTag "protobuf_field_name" }}
+	ProtobufType       string {{ .Config.JSONTag "protobuf_field_type" }}
+	ProtobufPos        int    {{ .Config.JSONTag "protobuf_field_pos" }}
+	Comment            string {{ .Config.JSONTag "comment" }}
+	Notes              string {{ .Config.JSONTag "notes" }}
+	Name               string {{ .Config.JSONTag "name" }}
+	Nullable           bool   {{ .Config.JSONTag "is_nullable" }}
+	DatabaseTypeName   string {{ .Config.JSONTag "database_type_name" }}
+	DatabaseTypePretty string {{ .Config.JSONTag "database_type_pretty" }}
+	IsPrimaryKey       bool   {{ .Config.JSONTag "is_primary_key" }}
+	IsAutoIncrement    bool   {{ .Config.JSONTag "is_auto_increment" }}
+	IsArray            bool   {{ .Config.JSONTag "is_array" }}
+	ColumnType         string {{ .Config.JSONTag "column_type" }}
+	ColumnLength       int64  {{ .Config.JSONTag "column_length" }}
+	DefaultValue       string {{ .Config.JSONTag "default_value" }}
 }
 
 // GetTableInfo retrieve TableInfo for a table

--- a/template/router.go.tmpl
+++ b/template/router.go.tmpl
@@ -25,29 +25,29 @@ var (
 
 // CrudAPI describes requests available for tables in the database
 type CrudAPI struct {
-	Name            string           `json:"name"`
-	CreateURL       string           `json:"create_url"`
-	RetrieveOneURL  string           `json:"retrieve_one_url"`
-	RetrieveManyURL string           `json:"retrieve_many_url"`
-	UpdateURL       string           `json:"update_url"`
-	DeleteURL       string           `json:"delete_url"`
-	FetchDDLURL     string           `json:"fetch_ddl_url"`
-	TableInfo       *{{.modelPackageName}}.TableInfo `json:"table_info"`
+	Name            string           {{ .Config.JSONTag "name" }}
+	CreateURL       string           {{ .Config.JSONTag "create_url" }}
+	RetrieveOneURL  string           {{ .Config.JSONTag "retrieve_one_url" }}
+	RetrieveManyURL string           {{ .Config.JSONTag "retrieve_many_url" }}
+	UpdateURL       string           {{ .Config.JSONTag "update_url" }}
+	DeleteURL       string           {{ .Config.JSONTag "delete_url" }}
+	FetchDDLURL     string           {{ .Config.JSONTag "fetch_ddl_url" }}
+	TableInfo       *{{.modelPackageName}}.TableInfo {{ .Config.JSONTag "table_info" }}
 }
 
 
 // PagedResults results for pages GetAll results.
 type PagedResults struct {
-	Page         int64       `json:"page"`
-	PageSize     int64       `json:"page_size"`
-	Data         interface{} `json:"data"`
-    TotalRecords int         `json:"total_records"`
+	Page         int64       {{ .Config.JSONTag "page" }}
+	PageSize     int64       {{ .Config.JSONTag "page_size" }}
+	Data         interface{} {{ .Config.JSONTag "data" }}
+    TotalRecords int         {{ .Config.JSONTag "total_records" }}
 }
 
 // HTTPError example
 type HTTPError struct {
-	Code    int    `json:"code" example:"400"`
-	Message string `json:"message" example:"status bad request"`
+	Code    int    `json:"{{ .Config.JSONFieldName "code" }}" example:"400"`
+	Message string `json:"{{ .Config.JSONFieldName "message"}}" example:"status bad request"`
 }
 
 


### PR DESCRIPTION
Hello again, I've added two fixes which are:
1. Adhere `json-fmt` flag for all JSON response so when `camel` or `lower_camel` is specified, fields name in `GetAll` variant and `DDL` info will also have the same name format
2. Fix:  Build information embedded through linker in Makefile is not consistent with the variable defined in `main` file.