### PR TITLE
Add import code fragment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Options:
   -t, --table=                                             Table to build struct from
   -x, --exclude=                                           Table(s) to exclude
   --templateDir=                                           Template Dir
+  --fragmentsDir=                                          Code fragments Dir
   --save=                                                  Save templates to dir
   --model=model                                            name to set for model package
   --model_naming={{FmtFieldName .}}                        model naming template to name structs

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 	sqlTable         = goopt.String([]string{"-t", "--table"}, "", "Table to build struct from")
 	excludeSQLTables = goopt.String([]string{"-x", "--exclude"}, "", "Table(s) to exclude")
 	templateDir      = goopt.String([]string{"--templateDir"}, "", "Template Dir")
+	fragmentsDir     = goopt.String([]string{"--fragmentsDir"}, "", "Code fragments Dir")
 	saveTemplateDir  = goopt.String([]string{"--save"}, "", "Save templates to dir")
 
 	modelPackageName    = goopt.String([]string{"--model"}, "model", "name to set for model package")
@@ -325,6 +326,11 @@ func initializeDB() (db *sql.DB, err error) {
 func initialize(conf *dbmeta.Config) {
 	if outDir == nil || *outDir == "" {
 		*outDir = "."
+	}
+
+	// load fragments if specified
+	if fragmentsDir != nil && *fragmentsDir != "" {
+		conf.LoadFragments(*fragmentsDir)
 	}
 
 	// if packageName is not set we need to default it


### PR DESCRIPTION
Hello,
thank you for the nice tool. I'm currently start to using it in my project. 
I've add new option to the tool to be able to `insert` code fragment into template for generating code.

The use case is that I want to separate between generated code and manually added code (hence the code fragment to be inserted) into separate file definition. So, every time we want to generate new code (e.g. when schema changes, etc.), manually written code is not overwritten.

The code fragment to be inserted is stored in separate file (can be multiple file, specified in `fragmentsDir` option), and those file will be loaded and combined into `bytes.Buffer` during initialization. Each fragment must be surrounded by:
```go
// fragment: <name>
// any golang fragment, e.g. additional import, fields definition, function, etc.
//end
``` 

Example:

```go
// fragment: Album-Imports
    "encoding/json"
// end


// fragment: Album-Fields
    Artist *Artist `json:"artist,omitempty"`
//end

// fragment: Album-Validation
    return Artist != nil
//end
```

Then in the `model.go.tmpl`, user just need to add the following function

```go
// 1. Import section
import (
    // other import definition
    {{insertFragment (print .StructName "-Imports") "" -}}
)

// 2. Struct definition
// {{.StructName}} struct is a row record of the {{.TableName}} table in the {{.DatabaseName}} database
type {{.StructName}} struct {
    {{range .TableInfo.Fields}}{{.}}
    {{end}}
    {{insertFragment (print .StructName "-Fields") "" -}}
}
{{else}}

// 3. Validation
// Validate invoked before performing action, return an error if field is not populated.
func ({{.ShortStructName}} *{{.StructName}}) Validate(action Action) error {
    {{insertFragment (print .StructName "-Validation") "" -}}
}
```

Best regards,
Putu 