### PR TITLE
Make changes to reflect gorm v1.2

### DIFF
--- a/dbmeta/meta_postgres.go
+++ b/dbmeta/meta_postgres.go
@@ -15,7 +15,6 @@ func LoadPostgresMeta(db *sql.DB, sqlType, sqlDatabase, tableName string) (DbTab
 		sqlDatabase: sqlDatabase,
 		tableName:   tableName,
 	}
-
 	cols, err := schema.Table(db, m.tableName)
 	if err != nil {
 		return nil, err
@@ -60,12 +59,11 @@ func LoadPostgresMeta(db *sql.DB, sqlType, sqlDatabase, tableName string) (DbTab
 		}
 
 		definedType := v.DatabaseTypeName()
-
+		colDDL := v.DatabaseTypeName()
 		if definedType == "" {
 			definedType = "USER_DEFINED"
+			colDDL = "VARCHAR"
 		}
-
-		colDDL := v.DatabaseTypeName()
 
 		colMeta := &columnMeta{
 			index:            i,

--- a/dbmeta/meta_utils.go
+++ b/dbmeta/meta_utils.go
@@ -3,10 +3,11 @@ package dbmeta
 import (
 	"database/sql"
 	"fmt"
-	"github.com/logrusorgru/aurora"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/logrusorgru/aurora"
 )
 
 var (
@@ -216,6 +217,9 @@ func cleanupDefault(val string) string {
 
 	if strings.LastIndex(val, "::") > -1 {
 		return cleanupDefault(val[0:strings.LastIndex(val, "::")])
+	}
+	if strings.HasPrefix(val, "'") && strings.HasSuffix(val, "'") {
+		return cleanupDefault(val[1 : len(val)-1])
 	}
 	// 'G'::mpaa_rating
 	// ('now'::text)::date

--- a/go.mod
+++ b/go.mod
@@ -8,40 +8,38 @@ require (
 	github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73
 	github.com/droundy/goopt v0.0.0-20170604162106-0b8effe182da
 	github.com/fzipp/gocyclo v0.0.0-20150627053110-6acd4345c835 // indirect
-	github.com/gin-gonic/gin v1.6.3
+	github.com/gin-gonic/gin v1.6.3 // indirect
 	github.com/gobuffalo/packd v1.0.0
 	github.com/gobuffalo/packr/v2 v2.8.0
-	github.com/gogo/protobuf v1.3.1
+	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/guregu/null v4.0.0+incompatible
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/jimsmart/schema v0.0.4
 	github.com/jinzhu/gorm v1.9.11
 	github.com/jinzhu/inflection v1.0.0
-	github.com/julienschmidt/httprouter v1.2.0
-	github.com/karrick/godirwalk v1.15.6 // indirect
+	github.com/karrick/godirwalk v1.16.1 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/lib/pq v1.3.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/ompluscator/dynamic-struct v1.2.0
-	github.com/rogpeppe/go-internal v1.6.0 // indirect
+	github.com/rogpeppe/go-internal v1.6.2 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516
-	github.com/sirupsen/logrus v1.6.0
+	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/spf13/cobra v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
+	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
-	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
-	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
-	golang.org/x/tools v0.0.0-20200730200120-fe6bb45d2132 // indirect
+	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520 // indirect
+	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
+	golang.org/x/tools v0.0.0-20201013015553-ec925d8b1dc6 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
-	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.24.0 // indirect
-	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gorm.io/gorm v1.20.2
 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 )

--- a/template/dao_gorm_add.go.tmpl
+++ b/template/dao_gorm_add.go.tmpl
@@ -2,7 +2,7 @@
 // Add{{.StructName}} is a function to add a single record to {{.TableName}} table in the {{.DatabaseName}} database
 // error - ErrInsertFailed, db save call failed
 func Add{{.StructName}}(ctx context.Context, record *{{.modelPackageName}}.{{.StructName}}) (result *{{.modelPackageName}}.{{.StructName}}, RowsAffected int64, err error) {
-    db := DB.Save(record)
+    db := DB.Create(record)
 	if err = db.Error; err != nil {
 	    return nil, -1, ErrInsertFailed
 	}

--- a/template/dao_gorm_delete.go.tmpl
+++ b/template/dao_gorm_delete.go.tmpl
@@ -5,7 +5,7 @@
 func Delete{{.StructName}}(ctx context.Context,{{range $field := .TableInfo.CodeFields}} {{ if $field.PrimaryKeyArgName }} {{$field.PrimaryKeyArgName}} {{$field.GoFieldType}},{{end}}{{end -}}) (rowsAffected int64, err error) {
 
     record := &{{.modelPackageName}}.{{.StructName}}{}
-    db := DB.First(record, {{range $field := .TableInfo.CodeFields}} {{ if $field.PrimaryKeyArgName }} {{$field.PrimaryKeyArgName -}},{{end}}{{end}})
+    db := DB.First(record, {{range $field := .TableInfo.CodeFields}} {{ if $field.PrimaryKeyArgName }} "{{$field.ColumnMeta.Name}} = ?",{{$field.PrimaryKeyArgName}},{{end}}{{end}})
     if db.Error != nil {
         return -1, ErrNotFound
     }

--- a/template/dao_gorm_getall.go.tmpl
+++ b/template/dao_gorm_getall.go.tmpl
@@ -4,7 +4,7 @@
 // params - pagesize - number of records in a page  (defaults to 20)
 // params - order    - db sort order column
 // error - ErrNotFound, db Find error
-func GetAll{{.StructName}}(ctx context.Context, page, pagesize int64, order string) (results []*{{.modelPackageName}}.{{.StructName}}, totalRows int, err error) {
+func GetAll{{.StructName}}(ctx context.Context, page, pagesize int, order string) (results []*{{.modelPackageName}}.{{.StructName}}, totalRows int64, err error) {
 
 	resultOrm := DB.Model(&{{.modelPackageName}}.{{.StructName}}{})
     resultOrm.Count(&totalRows)

--- a/template/dao_gorm_init.go.tmpl
+++ b/template/dao_gorm_init.go.tmpl
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/jinzhu/gorm"
+	"gorm.io/gorm"
 )
 
 // BuildInfo is used to define the application build info, and inject values into via the build process.

--- a/template/dao_gorm_update.go.tmpl
+++ b/template/dao_gorm_update.go.tmpl
@@ -5,7 +5,7 @@
 func Update{{.StructName}}(ctx context.Context, {{range $field := .TableInfo.CodeFields}} {{ if $field.PrimaryKeyArgName }} {{$field.PrimaryKeyArgName}} {{$field.GoFieldType}},{{end}}{{end -}}updated *{{.modelPackageName}}.{{.StructName}}) (result *{{.modelPackageName}}.{{.StructName}}, RowsAffected int64, err error) {
 
    result = &{{.modelPackageName}}.{{.StructName}}{}
-   db := DB.First(result,{{range $field := .TableInfo.CodeFields}} {{ if $field.PrimaryKeyArgName }} {{$field.PrimaryKeyArgName}},{{end}}{{end -}})
+   db := DB.First(result,{{range $field := .TableInfo.CodeFields}} {{ if $field.PrimaryKeyArgName }} "{{$field.ColumnMeta.Name}} = ?",{{$field.PrimaryKeyArgName}},{{end}}{{end -}})
    if err = db.Error; err != nil {
       return nil, -1, ErrNotFound
    }

--- a/template/mapping.json
+++ b/template/mapping.json
@@ -437,11 +437,11 @@
     },
     {
       "sql_type": "USER_DEFINED",
-      "go_type": "interface{}",
+      "go_type": "string",
       "json_type": "Text",
       "protobuf_type": "bytes",
       "guregu_type": "interface{}",
-      "go_nullable_type": "interface{}",
+      "go_nullable_type": "sql.NullString",
       "swagger_type": "string"
     },
     {
@@ -455,11 +455,11 @@
     },
     {
       "sql_type": "",
-      "go_type": "interface{}",
+      "go_type": "string",
       "json_type": "Text",
       "protobuf_type": "bytes",
       "guregu_type": "interface{}",
-      "go_nullable_type": "interface{}",
+      "go_nullable_type": "sql.NullString",
       "swagger_type": "string"
     },
     {

--- a/template/model.go.tmpl
+++ b/template/model.go.tmpl
@@ -6,6 +6,7 @@ import (
 
     "github.com/satori/go.uuid"
     "github.com/guregu/null"
+	"gorm.io/gorm"
 )
 
 var (
@@ -90,7 +91,7 @@ func ({{.ShortStructName}} *{{.StructName}}) TableName() string {
 }
 
 // BeforeSave invoked before saving, return an error if field is not populated.
-func ({{.ShortStructName}} *{{.StructName}}) BeforeSave() error {
+func ({{.ShortStructName}} *{{.StructName}}) BeforeSave(tx *gorm.DB) error {
 	return nil
 }
 


### PR DESCRIPTION
Treat ENUM types or user-defined types in Postgres as VARCHARS. 

Is there any chance to get this PR merged. gen is still using pre version 2 notion of GORM and few things have changed after GORM V2.  
Postgres enums can be treated as strings. Is it possible to inlcude this change