### PR TITLE
golint friendly changes.

### DIFF
--- a/dbmeta/meta.go
+++ b/dbmeta/meta.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/bxcodec/faker/v3"
 	"github.com/iancoleman/strcase"
-	"github.com/ompluscator/dynamic-struct"
+	dynamicstruct "github.com/ompluscator/dynamic-struct"
 )
 
 type metaDataLoader func(db *sql.DB, sqlType, sqlDatabase, tableName string) (DbTableMeta, error)
@@ -764,7 +764,7 @@ func GenerateModelInfo(tables map[string]*ModelInfo, dbMeta DbTableMeta,
 		generator = generator.AddField(c.GoFieldName, fakeData, tag)
 		if meta.IsPrimaryKey() {
 			//c.PrimaryKeyArgName = RenameReservedName(strcase.ToLowerCamel(c.GoFieldName))
-			c.PrimaryKeyArgName = fmt.Sprintf("arg%s", strcase.ToCamel(c.GoFieldName))
+			c.PrimaryKeyArgName = fmt.Sprintf("arg%s", FmtFieldName(c.GoFieldName))
 			noOfPrimaryKeys++
 		}
 	}

--- a/dbmeta/util.go
+++ b/dbmeta/util.go
@@ -45,6 +45,7 @@ var commonInitialisms = map[string]bool{
 	"UTF8":  true,
 	"VM":    true,
 	"XML":   true,
+	"ACL":   true,
 }
 
 var intToWordMap = []string{


### PR DESCRIPTION
This avoids any issues with golint. 
if the primary key has Id this change makes it argID instead of argId which is a golint violation
Also capitalises ACL when it is at the end of a struct name