### PR TITLE
added check_prereq to target install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 	$(warning "found packr2")
 
 
-install: ## go install binary info $GOPATH/bin
+install: check_prereq ## go install binary info $GOPATH/bin
 	packr2 install github.com/smallnest/gen
 
 vet: ## run go vet on the project


### PR DESCRIPTION
if one doesn't have github.com/gobuffalo/packr/v2/packr2 installed and clones the repo and trys ```make install``` it will fail due to packr2 not being available