### PR TITLE
Primary key column parsed type added time.Time

### DIFF
--- a/dbmeta/util.go
+++ b/dbmeta/util.go
@@ -73,6 +73,7 @@ var parsePrimaryKeys = map[string]string{
 	"int64":     "parseInt64",
 	"string":    "parseString",
 	"uuid.UUID": "parseUUID",
+	"time.Time": "parseTime",
 }
 
 var reservedFieldNames = map[string]bool{


### PR DESCRIPTION
postgre database timestamp range partioned table is pk column add required. parsePrimaryKeys add time.Time skip table problem solved.