### PR TITLE
organize imports on generated code

### DIFF
--- a/dbmeta/codegen.go
+++ b/dbmeta/codegen.go
@@ -22,6 +22,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/jinzhu/inflection"
 	"github.com/serenize/snaker"
+	"golang.org/x/tools/imports"
 )
 
 // GenTemplate template info struct
@@ -234,6 +235,10 @@ func camelToUpperCamel(s string) string {
 // FormatSource format source code contents
 func FormatSource(s string) string {
 	formattedSource, err := format.Source([]byte(s))
+	if err != nil {
+		return fmt.Sprintf("Error in formatting source: %s\n", err.Error())
+	}
+	formattedSource, err = imports.Process("", formattedSource, nil)
 	if err != nil {
 		return fmt.Sprintf("Error in formatting source: %s\n", err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,5 @@ require (
 	github.com/serenize/snaker v0.0.0-20171204205717-a683aaf2d516
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee // indirect
+	golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e
 )

--- a/template/api.go.tmpl
+++ b/template/api.go.tmpl
@@ -11,10 +11,6 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-var (
-    _ = null.Bool{}
-)
-
 func config{{.StructName}}Router(router *httprouter.Router) {
 	router.GET("/{{.StructName | toLower}}", GetAll{{.StructName}})
 	router.POST("/{{.StructName | toLower}}", Add{{.StructName}})

--- a/template/model.go.tmpl
+++ b/template/model.go.tmpl
@@ -9,13 +9,6 @@ import (
 	"gorm.io/gorm"
 )
 
-var (
-    _ = time.Second
-    _ = sql.LevelDefault
-    _ = null.Bool{}
-    _ = uuid.UUID{}
-)
-
 /*
 DB Table Details
 -------------------------------------

--- a/template/router.go.tmpl
+++ b/template/router.go.tmpl
@@ -19,10 +19,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
-var (
-    _ = time.Second // import time.Second for unknown usage in api
-	crudEndpoints map[string]*CrudAPI
-)
+var crudEndpoints map[string]*CrudAPI
 
 // CrudAPI describes requests available for tables in the database
 type CrudAPI struct {


### PR DESCRIPTION
Clean the generated code by organizing imports to avoid that line

```go
_ = time.Second // import time.Second for unknown usage in api
```