### PR TITLE
fix sample.gen exec error

### DIFF
--- a/custom/sample.gen
+++ b/custom/sample.gen
@@ -61,9 +61,9 @@ func (c *Config) GenerateFile(templateFilename, outDir, outputDirectory, outputF
    {{$name := toUpper $table.TableName -}}
    {{$filename  := printf "My%s.go" $name -}}
    {{ printf "[%-2d] %-20s %-20s" $i $name $filename}}
-   {{ GenerateTableFile $.tableInfos $table.TableName  "custom.go.tmpl" "test" $filename true}}{{- end }}
+   {{ GenerateTableFile $table.TableName  "custom.go.tmpl" "test" $filename}}{{- end }}
 
-{{ GenerateFile "custom.md.tmpl" "test" "custom.md" false false }}
+{{ GenerateFile "custom.md.tmpl" "test" "custom.md" false}}
 
 
 {{ mkdir "test/alex/test/mkdir" }}


### PR DESCRIPTION
when i `exec=./custom/simple.gen` get error:
Executing script ./sample.gen
Error in rendering /Users/admin/test/gen/gen/custom/sample.gen: template: sample.gen:66:3: executing "sample.gen" at <GenerateFile>: wrong number of args for GenerateFile: want 4 got 5
Error Loading exec script: ./sample.gen, error: template: sample.gen:66:3: executing "sample.gen" at <GenerateFile>: wrong number of args for GenerateFile: want 4 got 5
Error in executing custom script template: sample.gen:66:3: executing "sample.gen" at <GenerateFile>: wrong number of args for GenerateFile: want 4 got 5

Because last version change the funcs GenerateFile and GenerateTableFile sign.

This PR will fix the `sample.gen`func call.