### PR TITLE
fix CVE-2021-3538

### DIFF
--- a/template/dao_gorm.go.tmpl
+++ b/template/dao_gorm.go.tmpl
@@ -7,7 +7,7 @@ import (
 	"{{.modelFQPN}}"
 
     {{if .UseGuregu}} "github.com/guregu/null" {{end}}
-    "github.com/satori/go.uuid"
+    "github.com/google/uuid"
 )
 
 var (

--- a/template/dao_sqlx.go.tmpl
+++ b/template/dao_sqlx.go.tmpl
@@ -9,7 +9,7 @@ import (
 	"{{.modelFQPN}}"
 
     {{if .UseGuregu}} "github.com/guregu/null" {{end}}
-	"github.com/satori/go.uuid"
+	"github.com/google/uuid"
 )
 
 var (

--- a/template/gomod.tmpl
+++ b/template/gomod.tmpl
@@ -20,7 +20,7 @@ require (
     github.com/lib/pq v1.3.0
     github.com/mailru/easyjson v0.7.1 // indirect
     github.com/mattn/go-sqlite3 v2.0.2+incompatible
-    github.com/satori/go.uuid v1.2.0
+    github.com/google/uuid v1.3.0
     github.com/sirupsen/logrus v1.4.2
     github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14
     github.com/swaggo/gin-swagger v1.2.0

--- a/template/model.go.tmpl
+++ b/template/model.go.tmpl
@@ -4,7 +4,7 @@ import (
     "database/sql"
     "time"
 
-    "github.com/satori/go.uuid"
+    "github.com/google/uuid"
     {{if .UseGuregu}} "github.com/guregu/null" {{end}}
 	"gorm.io/datatypes"
 	"gorm.io/gorm"

--- a/template/router.go.tmpl
+++ b/template/router.go.tmpl
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"time"
 	"unsafe"
-	_ "github.com/satori/go.uuid"
+	_ "github.com/google/uuid"
 
 	"{{.daoFQPN}}"
 	"{{.modelFQPN}}"


### PR DESCRIPTION
Dependency go:github.com/satori/go.uuid:v1.2.0 is vulnerable
CVE-2021-3538 9.8 Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG) vulnerability with high severity found

So use `github.com/google/uuid:v1.3.0` to replace `github.com/satori/go.uuid:v1.2.0`